### PR TITLE
Add linkage name attribute recognition to DIEs

### DIFF
--- a/libpstack/dwarf/attr.h
+++ b/libpstack/dwarf/attr.h
@@ -68,6 +68,7 @@ DWARF_ATTR(DW_AT_ranges, 0x55)
 DWARF_ATTR(DW_AT_trampoline, 0x56)
 DWARF_ATTR(DW_AT_call_column, 0x57)
 DWARF_ATTR(DW_AT_call_file, 0x58)
+DWARF_ATTR(DW_AT_linkage_name, 0x6E)
 
 DWARF_ATTR(DW_AT_lo_user, 0x2000)
 DWARF_ATTR(DW_AT_hi_user, 0x3fff)


### PR DESCRIPTION
Making the linkage name available enables the direct use of mangled symbols (and is probably good to have anyway)