### PR TITLE
Improved error messages & Experimental Python 3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ enable_testing()
 
 add_subdirectory(tests)
 
+option(PYTHON3 "Compile with experimental python 3 support" OFF)
+
 math(EXPR PLATFORM_BITS "${CMAKE_SIZEOF_VOID_P} * 8")
 set(PSTACK_BIN "pstack" CACHE STRING "Name of the 'pstack' binary")
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" CACHE STRING "Rpath to install for binaries or the empty string")
@@ -13,8 +15,10 @@ option(TIDY "Run clang-tidy on the source" False)
 find_library(LTHREADDB NAMES thread_db PATHS (/usr/lib /usr/local/lib))
 find_package(LibLZMA)
 find_package(ZLIB)
-find_package(Python3 COMPONENTS Development)
 find_package(Python2 COMPONENTS Development)
+if (PYTHON3)
+   find_package(Python3 COMPONENTS Development)
+endif()
 
 find_package(Git)
 if (GIT_FOUND)
@@ -57,7 +61,7 @@ if (Python3_Development_FOUND OR Python2_Development_FOUND)
    set(pysrc python.cc)
 endif()
 
-if (False AND Python3_Development_FOUND)
+if (PYTHON3 AND Python3_Development_FOUND)
    message(STATUS  "Python3_INCLUDE_DIRS are ${Python3_INCLUDE_DIRS}")
    set(pysrc ${pysrc} python3.cc)
    add_definitions("-DWITH_PYTHON3")
@@ -106,7 +110,7 @@ else()
    message(WARNING "no LZMA support found")
 endif()
 
-if (NOT (Python3_Development_FOUND))
+if ((NOT (Python3_Development_FOUND)) AND PYTHON3)
    message(WARNING "no python3 support found")
 endif()
 

--- a/libpstack/python.h
+++ b/libpstack/python.h
@@ -39,6 +39,7 @@ template <int V, typename T> T readPyObj(const Reader &r, off_t offset) {
     return r.readObj<VersionedType<V, T>>(offset).t;
 }
 
+template <int V> std::string readString(const Reader &r, const Elf::Addr addr);
 
 template <int V>
 class PythonTypePrinter {

--- a/libpstack/python.h
+++ b/libpstack/python.h
@@ -1,5 +1,20 @@
+#ifndef PSTACK_PYTHON_H
+#define PSTACK_PYTHON_H
+
 #include "libpstack/elf.h"
 #include "libpstack/proc.h"
+
+// version to hex
+#define V2HEX(major, minor) ((major << 24) | (minor << 16))
+
+struct PyInterpInfo {
+    Elf::Object::sptr libpython;
+    Elf::Addr libpythonAddr;
+    Elf::Addr interpreterHead;
+    std::string version;
+    int versionHex;
+};
+
 template <int PyV> struct PythonPrinter;
 
 struct _object;
@@ -50,7 +65,7 @@ struct PythonPrinter {
     };
     mutable std::map<_typeobject *, std::unique_ptr<_typeobject, freetype>> types;
 
-    PythonPrinter(Process &proc_, std::ostream &os_, const PstackOptions &);
+    PythonPrinter(Process &proc_, std::ostream &os_, const PstackOptions &, const PyInterpInfo &info_);
     const char *prefix() const;
     void printInterpreters(bool withModules);
     Elf::Addr printThread(Elf::Addr);
@@ -64,9 +79,11 @@ struct PythonPrinter {
     Elf::Object::sptr libpython;
     Elf::Addr libpythonAddr;
     const PstackOptions &options;
+    const PyInterpInfo &info;
     std::map<const _typeobject *, const PythonTypePrinter<PyV> *> printers;
-    void findInterpreter();
     bool interpFound() const; // returns true if the printer could find the interpreter.
-    void findInterpHeadFallback();
 };
 bool pthreadTidOffset(const Process &proc, size_t *offsetp);
+PyInterpInfo getPyInterpInfo(const Process &proc);
+
+#endif

--- a/python2.cc
+++ b/python2.cc
@@ -86,32 +86,6 @@ class IntPrint : public PythonTypePrinter<2> {
 };
 static IntPrint intPrinter;
 
-template<>
-void PythonPrinter<2>::findInterpHeadFallback() {
-    libpython = nullptr;
-    for (auto &o : proc.objects) {
-        std::string module = stringify(*o.second->io);
-        if (module.find("python") == std::string::npos)
-            continue;
-        auto image = o.second;
-        auto &syms = image->commonSections->debugSymbols;
-        for (auto sym : syms) {
-            if (sym.name.substr(0, 11) != "interp_head")
-                continue;
-            libpython = o.second;
-            libpythonAddr = o.first;
-            interp_head = libpythonAddr + sym.symbol.st_value;
-            break;
-        }
-        if (interp_head)
-            break;
-    }
-    if (libpython == nullptr)
-        throw Exception() << "No libpython found";
-    if (verbose)
-       *debug << "python2 library is " << *libpython->io << std::endl;
-}
-
 #include "python.tcc"
 
 template struct PythonPrinter<2>;

--- a/python2.cc
+++ b/python2.cc
@@ -6,6 +6,17 @@ template<> std::set<const PythonTypePrinter<2> *> PythonTypePrinter<2>::all = st
 template<>
 char PythonTypePrinter<2>::pyBytesType[] = "PyString_Type";
 
+/**
+ * @brief Reads a Python2 string
+ * 
+ * @param r The reader used
+ * @param addr Address of PyStringObject
+ * @return std::string 
+ */
+template <> std::string readString<2>(const Reader &r, const Elf::Addr addr) {
+    return r.readString(addr + offsetof(PyBytesObject, ob_sval));
+}
+
 class BoolPrint : public PythonTypePrinter<2> {
     Elf::Addr print(const PythonPrinter<2> *pc, const PyObject *pyo, const PyTypeObject *, Elf::Addr) const override {
         auto pio = (const PyIntObject *)pyo;

--- a/python3.cc
+++ b/python3.cc
@@ -1,8 +1,10 @@
 #include <python3.7/Python.h>
 #include <python3.7/frameobject.h>
+#include <python3.7/dictobject.h>
 #include <python3.7/longintrepr.h>
 #include <python3.7/longintrepr.h>
 #include <python3.7/unicodeobject.h>
+#include "../cpython3.7.10/Objects/dict-common.h"
 #include "libpstack/python.h"
 
 template<> std::set<const PythonTypePrinter<3> *> PythonTypePrinter<3>::all = std::set<const PythonTypePrinter<3> *>();
@@ -30,6 +32,32 @@ template <> std::string readString<3>(const Reader &r, const Elf::Addr addr) {
        return r.readString(addr + offsetof(PyUnicodeObject, data));
     }
 }
+
+// class DictPrinter : public PythonTypePrinter<2> {
+//     Elf::Addr print(const PythonPrinter<2> *pc, const PyObject *pyo, const PyTypeObject *, Elf::Addr) const override {
+//         PyDictObject *pdo = (PyDictObject *)pyo;
+//         if (pdo->ma_used == 0)
+//             return 0;
+        
+//         if (pdo->ma_values == NULL) { //Combined table
+//             for (Py_ssize_t i = 0; i < pdo->ma_used; ++i) {
+//                 PyDictKeysObject key = readPyObj<3, PyDictKeysObject>(*pc->proc.io, Elf::Addr(pdo->ma_values + i));
+//             }
+//         } else { //Split table
+//             for (Py_ssize_t i = 0; i < pdo->ma_used; ++i) {
+//                 PyDictKeysObject key = readPyObj<3, PyDictKeysObject>(*pc->proc.io, Elf::Addr(pdo->ma_values + i));
+//                 PyObject value = readPyObj<3, PyObject>(*pc->proc.io, Elf::Addr(pdo->ma_values + i));
+//             }
+//         }
+
+//         for (Py_ssize_t i = 0; i < pdo->ma_used ; ++i) {
+//         }
+//         return 0;
+//     }
+//     const char *type() const override { return "PyDict_Type"; }
+//     bool dupdetect() const override { return true; }
+// };
+// static DictPrinter dictPrinter;
 
 class BoolPrinter : public PythonTypePrinter<3> {
     Elf::Addr print(const PythonPrinter<3> *pc, const PyObject *pyo, const PyTypeObject *, Elf::Addr) const override {

--- a/python3.cc
+++ b/python3.cc
@@ -7,7 +7,29 @@
 
 template<> std::set<const PythonTypePrinter<3> *> PythonTypePrinter<3>::all = std::set<const PythonTypePrinter<3> *>();
 template <>
-char PythonTypePrinter<3>::pyBytesType[] = "PyBytes_Type";
+char PythonTypePrinter<3>::pyBytesType[] = "PyUnicode_Type";
+
+/**
+ * @brief Converts a Python PyASCIIObject, PyCompactUnicodeObject or PyUnicodeObjec to a string
+ * 
+ * @param r The reader used
+ * @param addr Address of the object
+ * @return std::string 
+ */
+template <> std::string readString<3>(const Reader &r, const Elf::Addr addr) {
+    PyASCIIObject baseObj = r.readObj<PyASCIIObject>(addr);
+    int ascii = baseObj.state.ascii;
+    int compact = baseObj.state.compact;
+    int ready = baseObj.state.ready;
+
+    if (compact && ascii && ready) {
+        return r.readString(addr + sizeof(PyASCIIObject));
+    } else if (compact & ready) {
+        return r.readString(addr + sizeof(PyCompactUnicodeObject));
+    } else {
+       return r.readString(addr + offsetof(PyUnicodeObject, data));
+    }
+}
 
 class BoolPrinter : public PythonTypePrinter<3> {
     Elf::Addr print(const PythonPrinter<3> *pc, const PyObject *pyo, const PyTypeObject *, Elf::Addr) const override {

--- a/python3.cc
+++ b/python3.cc
@@ -1,7 +1,8 @@
-#include <python3.8/Python.h>
-#include <python3.8/frameobject.h>
-#include <python3.8/longintrepr.h>
-#include <python3.8/longintrepr.h>
+#include <python3.7/Python.h>
+#include <python3.7/frameobject.h>
+#include <python3.7/longintrepr.h>
+#include <python3.7/longintrepr.h>
+#include <python3.7/unicodeobject.h>
 #include "libpstack/python.h"
 
 template<> std::set<const PythonTypePrinter<3> *> PythonTypePrinter<3>::all = std::set<const PythonTypePrinter<3> *>();
@@ -18,72 +19,6 @@ class BoolPrinter : public PythonTypePrinter<3> {
     bool dupdetect() const override { return false; }
 };
 static BoolPrinter boolPrinter;
-
-template<>
-void PythonPrinter<3>::findInterpHeadFallback() {
-    libpython = nullptr;
-
-    Elf::Addr pyRuntime;
-    std::tie(libpython, libpythonAddr, pyRuntime) = proc.findSymbolDetail("_PyRuntime", false);
-    if (pyRuntime == 0)
-       return;
-#if 0
-    typedef struct pyruntimestate {
-        /* Is Python pre-initialized? Set to 1 by Py_PreInitialize() */
-        int pre_initialized;
-
-        /* Is Python core initialized? Set to 1 by _Py_InitializeCore() */
-        int core_initialized;
-
-        /* Is Python fully initialized? Set to 1 by Py_Initialize() */
-        int initialized;
-
-        PyThreadState *finalizing;
-
-        struct pyinterpreters {
-"void *"->  PyThread_type_lock mutex;
-WANT THIS-> PyInterpreterState *head;
-            PyInterpreterState *main;
-            /* _next_interp_id is an auto-numbered sequence of small
-               integers.  It gets initialized in _PyInterpreterState_Init(),
-               which is called in Py_Initialize(), and used in
-               PyInterpreterState_New().  A negative interpreter ID
-               indicates an error occurred.  The main interpreter will
-               always have an ID of 0.  Overflow results in a RuntimeError.
-               If that becomes a problem later then we can adjust, e.g. by
-               using a Python int. */
-            int64_t next_id;
-        } interpreters;
-        // XXX Remove this field once we have a tp_* slot.
-        struct _xidregistry {
-            PyThread_type_lock mutex;
-            struct _xidregitem *head;
-        } xidregistry;
-
-        unsigned long main_thread;
-
-#define NEXITFUNCS 32
-        void (*exitfuncs[NEXITFUNCS])(void);
-        int nexitfuncs;
-
-        struct _gc_runtime_state gc;
-        struct _ceval_runtime_state ceval;
-        struct _gilstate_runtime_state gilstate;
-
-        PyPreConfig preconfig;
-
-        Py_OpenCodeHookFunction open_code_hook;
-        void *open_code_userdata;
-        _Py_AuditHookEntry *audit_hook_head;
-
-    } _PyRuntimeState;
-#endif
-    interp_head = pyRuntime + sizeof(int) * 4  + sizeof(void *)*2;
-    if (verbose)
-       *debug << "python library is " << *libpython->io
-          << ", _PyRuntime at " << pyRuntime
-          << ", interp head is " << interp_head << std::endl;
-}
 
 #include "python.tcc"
 


### PR DESCRIPTION
Warning will be given if debug symbols for python2 aren't found

Notify the user that py3 isn't supported if they run pstack on a py3 program