### PR TITLE
Performance update to canal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ID
 .vscode
 ?32
 ?64
+build


### PR DESCRIPTION
Storing listed symbols to a std::map to eliminate duplicates;
reading larger chunks of the core file at a time (capped at 1M)

My experimentation yielded a 60% faster processing for a 4G core.

took the liberty to add "build" into .gitignore, since it is the most common CMake build dir.