### PR TITLE
Fix #14

### DIFF
--- a/python.tcc
+++ b/python.tcc
@@ -356,7 +356,7 @@ PythonPrinter<PyV>::print(Elf::Addr remoteAddr) const {
             ssize_t fullSize;
             if (itemsize != 0) {
                 // object is a variable length object:
-                if (baseObj.ob_size > 65536) {
+                if (abs(baseObj.ob_size) > 65536) {
                     os << "(skip massive object " << baseObj.ob_size << ")";
                     break;
                 }


### PR DESCRIPTION
This is a fix for #14 

PyLongObject's were skipped due to having a negative ob_size when they use a negative ob_size to signifity that the long itself is negative