### PR TITLE
ProcMgr Prep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,14 +67,28 @@ if (Python3_Development_FOUND OR Python2_Development_FOUND)
 endif()
 
 if (PYTHON3 AND Python3_Development_FOUND)
-   message(STATUS  "Python3_INCLUDE_DIRS are ${Python3_INCLUDE_DIRS}")
-   set(pysrc ${pysrc} python3.cc)
-   add_definitions("-DWITH_PYTHON3")
-   set_source_files_properties(python3.cc PROPERTIES COMPILE_FLAGS -I${Python3_INCLUDE_DIRS})
    if ("${PYTHON3_SOURCE}" STREQUAL "") # not set
-      message(FATAL_ERROR "Path to CPython source code needed for Python 3 support\nSpecify with -DPYTHON3_SOURCE=<path>")
-   else()
+      message(STATUS "Python 3 source not specified. Checking /usr/src/debug/Python-3.* as default")
+
+      file(GLOB PYTHON3_SOURCE_GLOB "/usr/src/debug/Python-3.*")
+
+      if ("${PYTHON3_SOURCE_GLOB}" STREQUAL "") # glob was empty
+         message(STATUS "Python 3 source not found")
+      else()
+         message(STATUS "Python3 source is \"${PYTHON3_SOURCE_GLOB}\"")
+         set(PYTHON3_SOURCE "${PYTHON3_SOURCE_GLOB}")
+      endif()
+   endif()
+
+
+   if (NOT "${PYTHON3_SOURCE}" STREQUAL "") # src found in some way
+      message(STATUS  "Python3_INCLUDE_DIRS are ${Python3_INCLUDE_DIRS}")
+      add_definitions("-DWITH_PYTHON3")
+      set(pysrc ${pysrc} python3.cc)
+      set_source_files_properties(python3.cc PROPERTIES COMPILE_FLAGS -I${Python3_INCLUDE_DIRS})
       set_property(SOURCE python3.cc APPEND PROPERTY COMPILE_OPTIONS "-I${PYTHON3_SOURCE}")
+   else()
+      message(FATAL_ERROR "Path to CPython source code needed for Python 3 support\nSpecify with -DPYTHON3_SOURCE=<path>")
    endif()
 endif()
 

--- a/libpstack/proc.h
+++ b/libpstack/proc.h
@@ -115,6 +115,7 @@ struct PstackOptions {
    enum Flags {
        nosrc,
        doargs,
+       dolocals,
        nothreaddb,
        maxopt // leave this last
    };

--- a/libpstack/proc.h
+++ b/libpstack/proc.h
@@ -121,6 +121,7 @@ struct PstackOptions {
    };
    std::bitset<maxopt> flags;
    std::vector<std::pair<std::string, std::string>> pathReplacements;
+   int maxdepth;
 };
 
 /*

--- a/libpstack/python.h
+++ b/libpstack/python.h
@@ -15,6 +15,14 @@ struct PyInterpInfo {
     int versionHex;
 };
 
+// See PyCodeObject.co_flags in <code.h>
+struct ArgFlags {
+    unsigned int         :  2; // Don't care
+    unsigned int varargs :  1; // If var args are used
+    unsigned int kwargs  :  1; // If kwargs are used
+    unsigned int         : 14; // Don't care
+};
+
 template <int PyV> struct PythonPrinter;
 
 struct _object;
@@ -40,6 +48,8 @@ template <int V, typename T> T readPyObj(const Reader &r, off_t offset) {
 }
 
 template <int V> std::string readString(const Reader &r, const Elf::Addr addr);
+template <int V> void printArguments(const PythonPrinter<V> *, const _object *, Elf::Addr addr);
+template <int V> int getKwonlyArgCount(const _object *);
 
 template <int V>
 class PythonTypePrinter {

--- a/pstack.cc
+++ b/pstack.cc
@@ -121,7 +121,7 @@ emain(int argc, char **argv)
 #endif
     bool coreOnExit = false;
 
-    while ((c = getopt(argc, argv, "F:b:d:CD:hjmsVvag:ptz:")) != -1) {
+    while ((c = getopt(argc, argv, "F:b:d:CD:hjmsVvag:pltz:")) != -1) {
         switch (c) {
         case 'F': g_openPrefix = optarg;
                   break;
@@ -168,6 +168,13 @@ emain(int argc, char **argv)
         case 'p':
 #if defined(WITH_PYTHON)
             python = true;
+#else
+            std::clog << "no python support compiled in" << std::endl;
+#endif
+            break;
+        case 'l':
+#if defined(WITH_PYTHON)
+            options.flags.set(PstackOptions::dolocals);
 #else
             std::clog << "no python support compiled in" << std::endl;
 #endif
@@ -246,6 +253,7 @@ usage(const char *name)
         "\t[-b<n>]                      batch mode: repeat every 'n' seconds\n"
 #ifdef WITH_PYTHON
         "\t[-p]                         print python backtrace if available\n"
+        "\t[-l]                         show python locals if available"
 #endif
         "\t[<pid>|<core>|<executable>]* list cores and pids to examine. An executable\n"
         "\t                             will override use of in-core or in-process information\n"

--- a/pstack.cc
+++ b/pstack.cc
@@ -86,8 +86,11 @@ template<int V> void doPy(Process &proc, std::ostream &o, const PstackOptions &o
     printer.printInterpreters(showModules);
 }
 
-void pystack(Process &proc, std::ostream &o, const PstackOptions &options, bool showModules) {
+bool pystack(Process &proc, std::ostream &o, const PstackOptions &options, bool showModules) {
     PyInterpInfo info = getPyInterpInfo(proc);
+
+    if (info.libpython == nullptr) // not a python process or python interpreter not found
+        return false;
 
     if (info.versionHex < V2HEX(3, 0)) { // Python 2.x
 #ifdef WITH_PYTHON2
@@ -102,6 +105,8 @@ void pystack(Process &proc, std::ostream &o, const PstackOptions &options, bool 
         throw (Exception() << "no support for discovered python 3 interpreter");
 #endif
     }
+
+    return true;
 }
 #endif
 
@@ -207,8 +212,8 @@ emain(int argc, char **argv)
                 proc.load(options);
                 while (!interrupted) {
 #if defined(WITH_PYTHON)
-                    if (python) {
-                        pystack(proc, std::cout, options, pythonModules);
+                    if (python && pystack(proc, std::cout, options, pythonModules)) {
+                        return;
                     }
                     else
 #endif

--- a/pstack.cc
+++ b/pstack.cc
@@ -114,6 +114,7 @@ emain(int argc, char **argv)
     Dwarf::ImageCache imageCache;
     double sleepTime = 0.0;
     PstackOptions options;
+    options.maxdepth = 10000;
 
 #if defined(WITH_PYTHON)
     bool python = false;
@@ -121,7 +122,7 @@ emain(int argc, char **argv)
 #endif
     bool coreOnExit = false;
 
-    while ((c = getopt(argc, argv, "F:b:d:CD:hjmsVvag:pltz:")) != -1) {
+    while ((c = getopt(argc, argv, "F:b:d:CD:hjmsVvag:pltz:r:")) != -1) {
         switch (c) {
         case 'F': g_openPrefix = optarg;
                   break;
@@ -189,6 +190,9 @@ emain(int argc, char **argv)
         case 'C':
             coreOnExit = true;
             break;
+        case 'r':
+            options.maxdepth = strtod(optarg, nullptr);
+            break;
         default:
             return usage(argv[0]);
         }
@@ -253,7 +257,8 @@ usage(const char *name)
         "\t[-b<n>]                      batch mode: repeat every 'n' seconds\n"
 #ifdef WITH_PYTHON
         "\t[-p]                         print python backtrace if available\n"
-        "\t[-l]                         show python locals if available"
+        "\t[-l]                         show python locals if available\n"
+        "\t[-r<n>]                      the max recursion depth for printing\n"
 #endif
         "\t[<pid>|<core>|<executable>]* list cores and pids to examine. An executable\n"
         "\t                             will override use of in-core or in-process information\n"

--- a/python.cc
+++ b/python.cc
@@ -19,6 +19,9 @@ getPyInterpInfo(const Process &proc) {
     
     std::tie(libpython, libpythonAddr, interpreterHead) = getInterpHead(proc);
 
+    if (libpython == nullptr)
+        return PyInterpInfo {nullptr, 0, 0, "", 0};
+
     std::string filename = libpython->io->filename();
 
     auto index = filename.find("python");
@@ -128,7 +131,10 @@ getInterpHead(const Process &proc) {
             std::clog << "Python 3 interpreter not found" << std::endl;
     }
 
-    throw Exception() << "Couldn't find a Python interpreter";
+    if (verbose)
+        std::clog << "Couldn't find a python interpreter" << std::endl;
+
+    return std::make_tuple(nullptr, 0, 0);
 }
 
 // libpthread includes offsets for fields in various structures. We can use

--- a/python.tcc
+++ b/python.tcc
@@ -97,7 +97,7 @@ template<int PyV> class ListPrinter : public PythonTypePrinter<PyV> {
           pc->os << ",\n";
         }
         pc->depth--;
-        pc->os << pc->prefix() << "]\n";
+        pc->os << pc->prefix() << "]";
         return 0;
     }
     const char *type() const override { return "PyList_Type"; }
@@ -191,9 +191,16 @@ template <int PyV> class FramePrinter : public PythonTypePrinter<PyV> {
             auto lineNo = getLine<PyV>(*pc->proc.io, &code, pfo);
             auto func = readString<PyV>(*pc->proc.io, Elf::Addr(code.co_name));
             auto file = readString<PyV>(*pc->proc.io, Elf::Addr(code.co_filename));
-            pc->os << pc->prefix() << func << " in " << file << ":" << lineNo << "\n";
 
+            pc->os << pc->prefix() << func;
+            
             if (pc->options.flags[PstackOptions::doargs]) {
+                printArguments<PyV>(pc, pyo, remoteAddr);
+            }
+
+            pc->os << " in " << file << ":" << lineNo << std::endl;
+
+            if (pc->options.flags[PstackOptions::dolocals]) {
 
                 Elf::Addr flocals = remoteAddr + offsetof(PyFrameObject, f_localsplus);
 
@@ -211,7 +218,7 @@ template <int PyV> class FramePrinter : public PythonTypePrinter<PyV> {
             }
         }
 
-        if (pc->options.flags[PstackOptions::doargs] && pfo->f_locals != 0) {
+        if (pc->options.flags[PstackOptions::dolocals] && pfo->f_locals != 0) {
             pc->depth++;
             pc->os << pc->prefix() << "locals: " << std::endl;
             pc->print(Elf::Addr(pfo->f_locals));
@@ -223,6 +230,7 @@ template <int PyV> class FramePrinter : public PythonTypePrinter<PyV> {
     const char *type() const override { return "PyFrame_Type"; }
     bool dupdetect() const override { return true; }
 };
+
 
 template <int PyV>
 const char *
@@ -427,4 +435,80 @@ PythonPrinter<PyV>::printInterp(Elf::Addr ptr, bool showModules)
        print(state.modules);
     }
     return state.next;
+}
+
+template <int PyV>
+void printArguments(const PythonPrinter<PyV> *pc, const PyObject *pyo, Elf::Addr remoteAddr) {
+    const PyFrameObject* pfo = (PyFrameObject *)pyo;
+
+    const PyCodeObject &code = readPyObj<3, PyCodeObject>(*pc->proc.io, Elf::Addr(pfo->f_code));
+
+    ArgFlags flags = *(ArgFlags*)&code.co_flags;
+    int argCount = code.co_argcount;
+    int kwonlyArgCount = getKwonlyArgCount<PyV>((PyObject*)&code);
+    int totalArgCount = argCount + kwonlyArgCount + flags.varargs + flags.kwargs;
+
+    Elf::Addr varnamesAddr = Elf::Addr(code.co_varnames) + offsetof(PyTupleObject, ob_item);
+    Elf::Addr localsAddr = remoteAddr + offsetof(PyFrameObject, f_localsplus);
+
+    pc->os << "(";
+
+    PyObject *args[argCount];
+    pc->proc.io->readObj(localsAddr, args, argCount);
+
+    // Positional Arguments
+    for (int i = 0; i < argCount; i++) {
+        pc->print(Elf::Addr(args[i]));
+        if (i < totalArgCount - 1) pc->os << ", ";
+    }
+
+    // *args if present
+    if (flags.varargs) {
+        PyObject *varargName = readPyObj<PyV, PyObject *>(*pc->proc.io, varnamesAddr + (argCount + kwonlyArgCount) * sizeof(PyObject *));
+        pc->print(Elf::Addr(varargName));
+        pc->os << "=(";
+        
+        // Varargs tuple pointer is always after all the positional arguments and keyword-only arguments
+        const Elf::Addr tupleAddr = localsAddr + (argCount + kwonlyArgCount) * sizeof(PyObject *);
+        const PyTupleObject* tuplePtr = readPyObj<PyV, PyTupleObject*>(*pc->proc.io, tupleAddr);
+        const PyTupleObject varargs = readPyObj<PyV, PyTupleObject>(*pc->proc.io, Elf::Addr(tuplePtr));
+
+        auto varargCount = ((PyVarObject *)&varargs)->ob_size;
+
+        PyObject *objects[varargCount];
+        pc->proc.io->readObj(Elf::Addr(tuplePtr) + offsetof(PyTupleObject, ob_item), objects, varargCount);
+
+        for (int i = 0; i < varargCount; i++) {
+            pc->print(Elf::Addr(objects[i]));
+            if (i < varargCount - 1) pc->os << ", ";
+        }
+
+        pc->os << ")";
+        if (kwonlyArgCount > 0 || flags.kwargs) pc->os << ", ";
+    }
+
+    // keyword-only arguments
+    if (kwonlyArgCount > 0) {
+        PyObject *kwonlyArgNames[kwonlyArgCount];
+        PyObject *kwonlyArgs[kwonlyArgCount];
+        pc->proc.io->readObj(varnamesAddr + argCount * sizeof(PyObject *), kwonlyArgNames, kwonlyArgCount);
+        pc->proc.io->readObj(localsAddr + argCount * sizeof(PyObject *), kwonlyArgs, kwonlyArgCount);
+
+        for (int i = 0; i < kwonlyArgCount; i++) {
+            pc->os << readString<PyV>(*pc->proc.io, Elf::Addr(kwonlyArgNames[i])) << "=";
+            pc->print(Elf::Addr(kwonlyArgs[i]));
+            if (i < kwonlyArgCount - 1) pc->os << ", ";
+        }
+
+        if (flags.kwargs) pc->os << ", ";
+    }
+
+    // **kwargs if present
+    if (flags.kwargs) {
+        PyObject *kwargsVarname = readPyObj<PyV, PyObject *>(*pc->proc.io, varnamesAddr + sizeof(PyObject *) * (argCount + kwonlyArgCount + flags.varargs));
+        PyObject *kwargs = readPyObj<PyV, PyObject *>(*pc->proc.io, localsAddr + sizeof(PyObject *) * (argCount + kwonlyArgCount + flags.varargs));
+        pc->os << readString<PyV>(*pc->proc.io, Elf::Addr(kwargsVarname)) << "=";
+        pc->print(Elf::Addr(kwargs));
+    }
+    pc->os << ")";
 }

--- a/python.tcc
+++ b/python.tcc
@@ -135,8 +135,14 @@ template <int PyV> class LongPrinter : public PythonTypePrinter<PyV> {
 template <int PyV> class TuplePrinter : public PythonTypePrinter<PyV> {
     Elf::Addr print(const PythonPrinter<PyV> *pc, const PyObject *pyo, const PyTypeObject *, Elf::Addr remoteAddr) const override {
         auto tuple = reinterpret_cast<const PyTupleObject *>(pyo);
-        pc->os << "( \n";
         auto size = std::min(((PyVarObject *)tuple)->ob_size, Py_ssize_t(100));
+
+        if (size == 0) {
+            pc->os << "()";
+            return 0;
+        }
+
+        pc->os << "( \n";
         PyObject *objects[size];
         pc->proc.io->readObj(remoteAddr + offsetof(PyTupleObject, ob_item), &objects[0], size);
         pc->depth++;

--- a/python2.cc
+++ b/python2.cc
@@ -110,7 +110,7 @@ pyObjtype(const T *o) {
 }
 
 template <>
-int getKwonlyArgCount<2>(const PyObject *pyCode) {
+int getKwonlyArgCount<2>(const PyObject *) {
     return 0;
 }
 

--- a/python2.cc
+++ b/python2.cc
@@ -1,6 +1,7 @@
 #include <python2.7/Python.h>
 #include <python2.7/frameobject.h>
 #include <python2.7/longintrepr.h>
+#include <python2.7/methodobject.h>
 #include "libpstack/python.h"
 template<> std::set<const PythonTypePrinter<2> *> PythonTypePrinter<2>::all = std::set<const PythonTypePrinter<2> *>();
 template<>
@@ -95,6 +96,7 @@ class IntPrint : public PythonTypePrinter<2> {
     bool dupdetect() const override { return false; }
 
 };
+static IntPrint intPrinter;
 
 template <typename T, int pyv>
 ssize_t
@@ -107,8 +109,10 @@ pyObjtype(const T *o) {
    return o->ob_type;
 }
 
-
-static IntPrint intPrinter;
+template <>
+int getKwonlyArgCount<2>(const PyObject *pyCode) {
+    return 0;
+}
 
 #include "python.tcc"
 

--- a/python3.cc
+++ b/python3.cc
@@ -63,6 +63,11 @@ class DictPrinter : public PythonTypePrinter<3> {
             return 0;
         }
 
+        if (pc->depth > pc->options.maxdepth) {
+            pc->os << "{ ... }";
+            return 0;
+        }
+
         const PyDictKeysObject keys = readPyObj<3, PyDictKeysObject>(*pc->proc.io, Elf::Addr(dict->ma_keys));
         const size_t indexSize = DK_IXSIZE(&keys);
         const Elf::Addr keyEntries = Elf::Addr(dict->ma_keys) + offsetof(PyDictKeysObject, dk_indices) + (keys.dk_size * indexSize);

--- a/python3.cc
+++ b/python3.cc
@@ -5,6 +5,7 @@
 #include <longintrepr.h>
 #include <longintrepr.h>
 #include <unicodeobject.h>
+#include <methodobject.h>
 #include "libpstack/python.h"
 
 #define DK_SIZE(dk) ((dk)->dk_size)
@@ -57,8 +58,10 @@ int64_t readIndex(const Reader &r, const Elf::Addr addr, size_t indexSize) {
 class DictPrinter : public PythonTypePrinter<3> {
     Elf::Addr print(const PythonPrinter<3> *pc, const PyObject *object, const PyTypeObject *, Elf::Addr) const override {
         PyDictObject *dict = (PyDictObject *)object;
-        if (dict->ma_used == 0)
+        if (dict->ma_used == 0) {
+            pc->os << "{}";
             return 0;
+        }
 
         const PyDictKeysObject keys = readPyObj<3, PyDictKeysObject>(*pc->proc.io, Elf::Addr(dict->ma_keys));
         const size_t indexSize = DK_IXSIZE(&keys);
@@ -101,6 +104,7 @@ class BoolPrinter : public PythonTypePrinter<3> {
     const char *type() const override { return "PyBool_Type"; }
     bool dupdetect() const override { return false; }
 };
+static BoolPrinter boolPrinter;
 
 template <typename T, int pyv>  ssize_t
 pyRefcnt(const T *o) {
@@ -112,8 +116,11 @@ pyObjtype(const T *o) {
    return o->ob_base.ob_type;
 }
 
-
-static BoolPrinter boolPrinter;
+template <>
+int getKwonlyArgCount<3>(const PyObject *pyCode) {
+    const PyCodeObject* code = (PyCodeObject *)pyCode;
+    return code->co_kwonlyargcount;
+}
 
 #include "python.tcc"
 


### PR DESCRIPTION
**Arguments**
Implement argument printing for Python processes using the -a flag
Supports *varargs, keyword-only arguments and **kwargs
-a no longer prints any locals.

_Before_
<img width="300" alt="Screenshot 2021-05-24 at 10 01 12" src="https://user-images.githubusercontent.com/34107736/119326928-57342800-bc7a-11eb-9532-ee1b2b17dc65.png">

_After_
<img width="600" alt="Screenshot 2021-05-24 at 10 00 36" src="https://user-images.githubusercontent.com/34107736/119326900-500d1a00-bc7a-11eb-88d4-d95a33cf2ec0.png">

**Locals**
Locals are now printed with the -l flag

**Python 3 Source**
CMake will now auto search `/usr/src/debug/` for the Python 3 source if one is not specified.

**Misc**
Added -r to specify max recursion depth for printing locals.
Change -p to print the C stack trace if the process isn't a Python process