### PR TITLE
hdbg arm64 implementation proposal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ message(STATUS "Version: ${VERSION_TAG}")
 add_definitions("-DVERSION=${VERSION_TAG}")
 
 set(CMAKE_CXX_STANDARD 17)
-add_definitions("-std=c++17") # the above does not work for clang.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17") # the above does not work for clang.
 
 add_definitions("-Wall -Wextra -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE")
 # Adding frame pointers makes things easy to run performance measurements with,

--- a/heap.c
+++ b/heap.c
@@ -344,13 +344,7 @@ getframe(void ***bp, void  ***ip) {
          "ret;"
     );
 }
-#elif defined(__aarch64__) || defined(__arm__)
-void
-getframe(void ***bp, void  ***ip) {
-   //XXX: TODO: support aarch64
-}
-#else
-
+#elif defined(__i386__)
 static void __attribute__((naked,noinline,optimize("O0")))
 getframe(void ***bp, void  ***ip) {
     asm("mov (%esp), %ecx;"
@@ -359,6 +353,25 @@ getframe(void ***bp, void  ***ip) {
         "mov 4(%esp), %edx;"
         "mov %ebp, (%edx);"
         "ret;");
+}
+#elif defined(__aarch64__)
+static void __attribute__((noinline,optimize("O0")))
+getframe(void ***bp, void  ***ip) {
+    void *stackp, *framep;
+    asm(
+        "mov %0, sp;"
+        "mov %1, x29;"
+        "str %0, [%2];"
+        "str %1, [%3]"
+        : "=r"(stackp), "=r"(framep)
+        : "r"(ip), "r"(bp)
+	: "memory"
+    );
+}
+#else
+void
+getframe(void ***bp, void  ***ip) {
+   //XXX: TODO: support other relevant archs
 }
 #endif
 

--- a/heap.c
+++ b/heap.c
@@ -355,18 +355,12 @@ getframe(void ***bp, void  ***ip) {
         "ret;");
 }
 #elif defined(__aarch64__)
-static void __attribute__((noinline,optimize("O0")))
+static void __attribute__((naked,noinline,optimize("O0")))
 getframe(void ***bp, void  ***ip) {
-    void *stackp, *framep;
     asm(
-        "mov %0, sp;"
-        "mov %1, x29;"
-        "str %0, [%2];"
-        "str %1, [%3]"
-        : "=r"(stackp), "=r"(framep)
-        : "r"(ip), "r"(bp)
-	: "memory"
-    );
+	"mov x0, x29;"
+	"mov x1, x30;"
+	"ret;");
 }
 #else
 void

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,9 @@ project(pstack-tests C CXX)
 set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
-add_definitions("-std=c++17 -O0 -D_FORTIFY_SOURCE=0 -I${CMAKE_SOURCE_DIR}")
+add_definitions("-O0 -D_FORTIFY_SOURCE=0 -I${CMAKE_SOURCE_DIR}")
 
 add_library(testhelper STATIC abort.c)
 


### PR DESCRIPTION
x29 is the frame pointer register on arm64, we store them respectively using temporary vars.
note arm32 needs its own version.