### PR TITLE
include what you use, include algorithm to avoid build failure

### DIFF
--- a/dwarf_frame.cc
+++ b/dwarf_frame.cc
@@ -2,6 +2,7 @@
 #include "libpstack/dwarf_reader.h"
 #include "libpstack/global.h"
 #include <stack>
+#include <algorithm>
 
 namespace pstack::Dwarf {
 std::pair<uintmax_t, bool>


### PR DESCRIPTION
Thanks for implementing this amazing tool.
I encountered build failure because the algorithm is not included in pstaack_frame.cc
The error will be resolved if the algorithm is included.

<img width="581" alt="Screenshot 2024-06-17 at 10 50 56 PM" src="https://github.com/peadar/pstack/assets/17574130/ee5be4e2-5995-41ff-bdf6-137a379892d5">
