### PR TITLE
add Dockerfile for testing on almalinux 9 with py3

### DIFF
--- a/docker/alma9-with-py3/Dockerfile
+++ b/docker/alma9-with-py3/Dockerfile
@@ -1,0 +1,4 @@
+FROM almalinux:9
+RUN dnf install --enablerepo "baseos-debuginfo" -y epel-release cmake zlib-devel xz-devel python3-devel python3-debuginfo gcc g++
+WORKDIR /src/docker/alma9-with-py3
+CMD ls -lsa /usr/bin/cmake && mkdir -p release && cd release && cmake -DPYTHON3=ON -DPYTHON3_SOURCE="/usr/include/python3.9" -DCMAKE_BUILD_TYPE=Release ../../.. && make -j && cd .. && mkdir -p debug && cd debug && cmake -DCMAKE_BUILD_TYPE=Debug ../../.. && make -j && make test


### PR DESCRIPTION
The dockerfile includes all the necessary steps to test pstack on almalinux 9. The command which is ran in docker, that builds pstack has Python3 support enabled.