### PR TITLE
Vendorize python3 bits

### DIFF
--- a/python3.cc
+++ b/python3.cc
@@ -1,12 +1,12 @@
 #include <Python.h>
 #include <frameobject.h>
 #include <dictobject.h>
-#include <Objects/dict-common.h>
 #include <longintrepr.h>
 #include <longintrepr.h>
 #include <unicodeobject.h>
 #include <methodobject.h>
 #include "libpstack/python.h"
+#include "python3_dict_internal.h"
 
 #define DK_SIZE(dk) ((dk)->dk_size)
 #define DK_IXSIZE(dk)                \

--- a/python3_dict_internal.h
+++ b/python3_dict_internal.h
@@ -1,0 +1,68 @@
+#ifndef Py_DICT_COMMON_H
+#define Py_DICT_COMMON_H
+
+typedef struct {
+    /* Cached hash code of me_key. */
+    Py_hash_t me_hash;
+    PyObject *me_key;
+    PyObject *me_value; /* This field is only meaningful for combined tables */
+} PyDictKeyEntry;
+
+/* dict_lookup_func() returns index of entry which can be used like DK_ENTRIES(dk)[index].
+ * -1 when no entry found, -3 when compare raises error.
+ */
+typedef Py_ssize_t (*dict_lookup_func)
+    (PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
+
+#define DKIX_EMPTY (-1)
+#define DKIX_DUMMY (-2)  /* Used internally */
+#define DKIX_ERROR (-3)
+
+/* See dictobject.c for actual layout of DictKeysObject */
+struct _dictkeysobject {
+    Py_ssize_t dk_refcnt;
+
+    /* Size of the hash table (dk_indices). It must be a power of 2. */
+    Py_ssize_t dk_size;
+
+    /* Function to lookup in the hash table (dk_indices):
+
+       - lookdict(): general-purpose, and may return DKIX_ERROR if (and
+         only if) a comparison raises an exception.
+
+       - lookdict_unicode(): specialized to Unicode string keys, comparison of
+         which can never raise an exception; that function can never return
+         DKIX_ERROR.
+
+       - lookdict_unicode_nodummy(): similar to lookdict_unicode() but further
+         specialized for Unicode string keys that cannot be the <dummy> value.
+
+       - lookdict_split(): Version of lookdict() for split tables. */
+    dict_lookup_func dk_lookup;
+
+    /* Number of usable entries in dk_entries. */
+    Py_ssize_t dk_usable;
+
+    /* Number of used entries in dk_entries. */
+    Py_ssize_t dk_nentries;
+
+    /* Actual hash table of dk_size entries. It holds indices in dk_entries,
+       or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).
+
+       Indices must be: 0 <= indice < USABLE_FRACTION(dk_size).
+
+       The size in bytes of an indice depends on dk_size:
+
+       - 1 byte if dk_size <= 0xff (char*)
+       - 2 bytes if dk_size <= 0xffff (int16_t*)
+       - 4 bytes if dk_size <= 0xffffffff (int32_t*)
+       - 8 bytes otherwise (int64_t*)
+
+       Dynamically sized, SIZEOF_VOID_P is minimum. */
+    char dk_indices[];  /* char is required to avoid strict aliasing. */
+
+    /* "PyDictKeyEntry dk_entries[dk_usable];" array follows:
+       see the DK_ENTRIES() macro */
+};
+
+#endif

--- a/python3_dict_internal.h
+++ b/python3_dict_internal.h
@@ -1,3 +1,12 @@
+/* This file is a copy of a "Objects/dict-common.h" file from CPython source.
+ *
+ * https://github.com/python/cpython/blob/340a82d9cff7127bb5a777d8b9a30b861bb4beee/Objects/dict-common.h
+ *
+ * Should we switch to handling layouts of various Python3 releases, this
+ * header file needs to be replaced with a series of headers, each
+ * corresponding to each Python3 minor version.
+ */
+
 #ifndef Py_DICT_COMMON_H
 #define Py_DICT_COMMON_H
 


### PR DESCRIPTION
This patch brings a header file from the CPython source that defines the
implementation details of a dictionary, which is correct for Python
versions up to 3.11. Previously, the header was referenced directly with
the `#include <Objects/dict-common.h>` directive, with the assumption
that CPython's internals would be present somewhere in the include
directories.

With Python 3.11, the location of the definitions previously provided by
`dict-common.h` has been moved to `Internal/*`, which has broken the
builds on recent distro releases.

Since we don't differentiate between minor versions of Python when
reading the stack (the CPython source present on the build host
determines how Python dictionaries will be read), we may as well include
the header containing dict layout information here, directly in pstack.

Pstack uses a BSD-2-clause license, which is compatible with CPython's
PSFL.

The CPython version from which the header was copied is 3.9.21.