### PR TITLE
Fix !ZLIB compilation

### DIFF
--- a/elf.cc
+++ b/elf.cc
@@ -682,9 +682,9 @@ Reader::csptr Section::io() const {
 #ifndef WITH_ZLIB
     if (wantedZlib) {
         static bool warned = false;
-        if (!warned && debug) {
+        if (!warned && elf->context.debug) {
             warned = true;
-            *debug <<"warning: no support configured for compressed debug info in section "
+            *(elf->context.debug) <<"warning: no support configured for compressed debug info in section "
                 << name << " of " << *elf->io << std::endl;
         }
     }


### PR DESCRIPTION
Starting with af59ef83 the builds without WITH_ZLIB would fail due to `debug` not being defined.
The `Section` object has a reference to the elf it belongs to, and that elf has the context with the debug stream. This patch makes use of that relationship to push the debug messages.